### PR TITLE
change Gunma performance from Platinum Airline☆ to High-Touch☆Summer

### DIFF
--- a/my.html
+++ b/my.html
@@ -48,7 +48,6 @@
     <input type="checkbox" id="2018031001" class="checkbox">静岡公演    
     <input type="checkbox" id="2018031801" class="checkbox">東京公演
     <input type="checkbox" id="2018051201" class="checkbox">～Tomorrow Town～
-    <input type="checkbox" id="2016081401" class="checkbox">群馬公演
     <br><h3><strong>小倉唯 LIVE「Smiley Cherry」</strong></h3>
     <input type="checkbox" id="2017100901" class="checkbox">昼公演
     <input type="checkbox" id="2017100902" class="checkbox">夜公演
@@ -57,6 +56,7 @@
     <input type="checkbox" id="2016071001" class="checkbox">幕張2日目  
     <input type="checkbox" id="2016071701" class="checkbox">愛知公演
     <input type="checkbox" id="2016080601" class="checkbox">大阪公演    
+    <input type="checkbox" id="2016081401" class="checkbox">群馬公演
     <br><h3><strong>小倉唯 1st LIVE「HAPPY JAM」</strong></h3>
     <input type="checkbox" id="2015070501" class="checkbox">昼公演
     <input type="checkbox" id="2015070502" class="checkbox">夜公演


### PR DESCRIPTION
This pull request includes changes to the `my.html` file to update the list of concert performances. The most important changes involve the reordering of the 群馬公演 checkbox.

Changes to concert performances:

* Removed the 群馬公演 checkbox from the list of performances under Platinum Airline☆.
* Added the 群馬公演 checkbox to the list of performances under High-Touch☆Summer.

It seems that you made a correction error in the following commit.
https://github.com/tokiyui/Yui/commit/232e524fac24573b8ced7415683e3b660864cf2e